### PR TITLE
Support range requests

### DIFF
--- a/src/sw/controller.js
+++ b/src/sw/controller.js
@@ -107,16 +107,6 @@ function meetsInterceptionPreconditions (event) {
             return false
         }
 
-        // range requests not supported yet.
-        const isStreamingMedia = ['video', 'audio'].includes(destination)
-        // HLS works fine, no range requests involved.
-        const isHLS = url.includes('.m3u8')
-
-        // TODO: Add check for range header, skip if present
-        if (isStreamingMedia && !isHLS) {
-            return false
-        }
-
         // https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
         // "If a request is made to another origin with this mode set, the
         // result is simply an error."

--- a/src/sw/interceptor.js
+++ b/src/sw/interceptor.js
@@ -2,7 +2,7 @@ import toIterable from 'browser-readablestream-to-it'
 import createDebug from 'debug'
 import * as Sentry from '@sentry/browser'
 
-import { getCidPathFromURL } from '../utils.js'
+import { getCidPathFromURL, parseRange } from '../utils.js'
 
 const debug = createDebug('sw')
 const cl = console.log
@@ -14,6 +14,7 @@ export class Interceptor {
     constructor(cid, saturn, clientId, event) {
         this.cid = cid
         this.cidPath = getCidPathFromURL(event.request.url, cid)
+        this.range = parseRange(event.request.headers.get('Range'))
         this.saturn = saturn
         this.clientId = clientId
         this.event = event
@@ -36,7 +37,8 @@ export class Interceptor {
                     const opts = {
                         customerFallbackURL: self.event.request.url,
                         raceNodes: true,
-                        firstHitDNS: true
+                        firstHitDNS: true,
+                        range: self.range
                     }
                     const contentItr = await self.saturn.fetchContentWithFallback(
                         self.cidPath,

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,3 +80,43 @@ export function getCidPathFromURL(url, cid) {
 
     return cidPath
 }
+
+export function parseRange(rangeHeader) {
+  if (typeof rangeHeader !== 'string') {
+    return 
+  }
+
+  const index = rangeHeader.indexOf('=')
+
+  if (index === -1) {
+    return 
+  }
+
+  // split the range string
+  const arr = rangeHeader.slice(index + 1).split(',')
+  // TODO: support multi-range requests
+  if (arr.length !== 1) {
+    return 
+  }
+  const type = rangeHeader.slice(0, index)
+  if (type !== 'bytes') {
+    return 
+  }
+
+  const range = arr[0].split('-')
+  const rangeStart = parseInt(range[0], 10)
+  const rangeEnd = parseInt(range[1], 10)
+ 
+  // -nnn
+  if (isNaN(rangeStart)) {
+      if (isNaN(rangeEnd)) {
+        return 
+      }
+      return { rangeStart: -rangeEnd }
+  // nnn-
+  } else if (isNaN(rangeEnd)) {
+    return { rangeStart }
+  }
+
+  return { rangeStart, rangeEnd }
+}

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { findCIDInURL, getCidPathFromURL } from '#src/utils.js'
+import { findCIDInURL, getCidPathFromURL, parseRange } from '#src/utils.js'
 
 describe('controller', () => {
     it('should find cid in the subdomain', () => {
@@ -37,5 +37,25 @@ describe('controller', () => {
 
         const foundCidPath = getCidPathFromURL(url, cid)
         assert.strictEqual(foundCidPath, cidPath)
+    })
+
+    it('should parse ranges', () => {
+        assert.strictEqual(parseRange(undefined), undefined)
+        assert.strictEqual(parseRange(null), undefined)
+        assert.strictEqual(parseRange(''), undefined)
+        assert.strictEqual(parseRange('apples=0-1000'), undefined)
+        assert.strictEqual(parseRange('bytes=0-1000,2000-3000'), undefined)
+        assert.strictEqual(parseRange('bytes=cheese-crackers'), undefined)
+        assert.strictEqual(parseRange('bytes=cheese'), undefined)
+        assert.deepEqual(parseRange('bytes=0-1000'), {
+            rangeStart: 0,
+            rangeEnd: 1000
+        })
+        assert.deepEqual(parseRange('bytes=1000'), {
+            rangeStart: 1000
+        })
+        assert.deepEqual(parseRange('bytes=-1000'), {
+            rangeStart: -1000
+        })
     })
 })


### PR DESCRIPTION
# Goals

Support range requests in the service worker, allowing audio and video content to be loaded.

Requires an update to the JS Client once https://github.com/filecoin-saturn/js-client/pull/48 merges

# Implementation

- removes audio/video exclusion -- note that while we now support most variants of range requests, we don't support requests for multiple ranges at once (`Range: bytes=0-1000, 1500-2000`), and we probably should add a check that excludes these requests. I don't believe the browser tends to use this for audio/video though maybe @gruns knows, but it needs further investigation.
- add a function to parse the string syntax of the range header and turn it into the range object that is expected by the JS client
- parse range header in the interceptor and pass it in the options to the JSClient
- unit test for range parsing function

# Next Steps

- as stated, probably need to exclude multi-range requests from our worker (we may be able to handle this, but it's non-trivial
- need to update with the new JS client once merged
- this needs multiple levels of testing before we release to clients.